### PR TITLE
Fix typo in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Inserts given data (like below) DB collections, returns Promise.
 }
 ```
 
-### `clear(data)`
+### `clean(data)`
 Clear collections based on given data (data format is the same), returns Promise.
 
 ### `drop()`


### PR DESCRIPTION
A method named `clear` is documented, but the package exports a method named [`clean`](https://github.com/mikhail-angelov/mongo-unit/blob/master/index.js#L76). The simplest thing to do was to update the documentation.