### PR TITLE
Fix code snippet in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ add init.spec.js
 const mongoUnit = require('mongo-unit')
 
 mongoUnit.start().then(() => {
-  console.log('fake mongo is started: ', mongoUnit.getUrl)
-  process.env.DATABASE_URL = mongoUnit.getUrl // this var process.env.DATABASE_URL = will keep link to fake mongo
+  console.log('fake mongo is started: ', mongoUnit.getUrl())
+  process.env.DATABASE_URL = mongoUnit.getUrl() // this var process.env.DATABASE_URL = will keep link to fake mongo
   run() // this line start mocha tests
 })
 


### PR DESCRIPTION
In the "How to use it" section of the README, the code snippet provided is wrong. 
`getUrl` is referenced as a mongoUnit property instead of a method. This could confuse people.
This PR updates the code snippet from `mongoUnit.getUrl)` to `mongoUnit.getUrl())`