### PR TITLE
Allow to start up the Memory Server as a MongoMemoryReplSet fixes #42

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ It starts mongod on one of available port and returns Promise with URL to connec
 *  `opts.dbpath` - db path, default: `<node_modules/mongo-unit>\.mongo-unit`
 *  `opts.verbose` - enable debug logs, default: `false`
 *  `opts.version` - specify which version of mongo to download. e.g. `version=v3.6`
+*  `opts.useReplicateSet` - specify we want to start the memory server as a `MongoMemoryReplSet` needed to support transactions, default: `false`
 
 [mongodb-memory-server](https://github.com/nodkz/mongodb-memory-server) can also be configured via environment variables.
  For instance, `export MONGOMS_DEBUG=1`will activate debug logging in the memory server. See their docs for more information.

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 const Debug = require('debug')
 const portfinder = require('portfinder')
 const MongoClient = require('mongodb').MongoClient
-const { MongoMemoryServer } = require('mongodb-memory-server')
+const { MongoMemoryServer, MongoMemoryReplSet } = require('mongodb-memory-server')
 const fs = require('fs')
 const ps = require('ps-node')
 const debug = Debug('mongo-unit')
@@ -13,6 +13,7 @@ const defaultMongoOpts = {
   dbName: 'test',
   dbpath: defaultTempDir,
   port: 27017,
+  useReplicaSet: false
 }
 
 let mongod = null
@@ -22,20 +23,44 @@ let dbName
 
 function runMongo(opts, port) {
   const options = {
-    instance: {
+    autoStart: false
+  }
+
+  if (opts.version) {
+    options.binary = { version: opts.version }
+  }
+
+  let startPromise
+  if (opts.useReplicaSet) {
+    options.instanceOpts = [
+      {
+        port: port,
+        dbPath: opts.dbpath,
+        storageEngine: 'wiredTiger',
+      }
+    ]
+
+    options.replSet = {
+      dbName: opts.dbName,
+      storageEngine: 'wiredTiger'
+    }
+
+    mongod = new MongoMemoryReplSet(options)
+
+    startPromise = mongod.start().then(() => mongod.waitUntilRunning())
+  } else {
+    options.instance = {
       port: port,
       dbPath: opts.dbpath,
       dbName: opts.dbName,
       storageEngine: 'ephemeralForTest',
-    },
-    autoStart: false,
+    }
+
+    mongod = new MongoMemoryServer(options)
+    startPromise = mongod.start()
   }
-  if (opts.version) {
-    options.binary = { version: opts.version }
-  }
-  mongod = new MongoMemoryServer(options)
-  return mongod
-    .start()
+
+  return startPromise
     .then(() => {
       return mongod.getDbName()
     })
@@ -61,7 +86,7 @@ function start(opts) {
   if (dbUrl) {
     return Promise.resolve(dbUrl)
   } else {
-    makeSureTempDirExist(mongo_opts.dbpath)
+    makeSureTempDirExist(mongo_opts.dbpath, mongo_opts.useReplicaSet)
     return makeSureOtherMongoProcessesKilled(mongo_opts.dbpath)
       .then(() => getFreePort(mongo_opts.port))
       .then(port => runMongo(mongo_opts, port))
@@ -127,8 +152,11 @@ function getFreePort(possiblePort) {
   )
 }
 
-function makeSureTempDirExist(dir) {
+function makeSureTempDirExist(dir, useReplicaSet) {
   try {
+    if (useReplicaSet) {
+      fs.rmdirSync(dir, { recursive: true })
+    }
     fs.mkdirSync(dir)
   } catch (e) {
     if (e.code !== 'EEXIST') {


### PR DESCRIPTION
In order to be able to Unit Test code that makes use of the new MongoDB transaction support, the MongoDB Memory Server needs to be started as a Replica Set.

We need a new `useReplicaSet` option added to the `start` function to indicate we want to start the MongoDB Memory Server as a Replica Set.