### PR TITLE
Fix custom dbName

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ async function runMongo(opts, port) {
   }
   dbUrl = mongod.getUri()
   client = await MongoClient.connect(dbUrl, { useUnifiedTopology: true })
+  dbName = opts.dbName || defaultMongoOpts.dbName
   return dbUrl
 }
 

--- a/test.js
+++ b/test.js
@@ -4,7 +4,7 @@ const expect = require('chai').expect
 const MongoClient = require('mongodb').MongoClient
 const co = require('co')
 
-const DB_NAME = 'test'
+const DB_NAME = 'testDb'
 
 describe('mongo-unit', function () {
   this.timeout(10000000)


### PR DESCRIPTION
`load(data)`, `clean(data)`, `drop()`, `initDb(data)` and `dropDb()` were not working with a custom `dbName`. This PR fixes that and updates the test file to use a custom DB name. 

The issue can be verified by updating the `test.js` file to use `const DB_NAME = 'testDb'` on the `master` branch. When running `npm test` with that DB name, you will see tests failing. After applying this fix, these tests no longer fail.