### PR TITLE
Restore the functionality of `dbName` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ function start(opts) {
     Debug.enable('mongo-unit')
     Debug.enable('*')
   }
+  dbName = mongo_opts.dbName;
   if (dbUrl) {
     return Promise.resolve(dbUrl)
   } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongo-unit",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "mongo db for unit tests",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
The [`dbName` option in **mongodb-memory-server**](https://nodkz.github.io/mongodb-memory-server/docs/api/interfaces/mongo-memory-instance-opts#dbname) is now unused. The option as passed to `start` no longer works. And there's no other way of setting the DB in `mongo-unit`. Setting the `dbName` module variable from options allows setting the DB name again.