### PR TITLE
Fix rmDirSync deprecation

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ function getFreePort(possiblePort) {
 function makeSureTempDirExist(dir, useReplicaSet) {
   try {
     if (fs.existsSync(dir)) {
-      fs.rmdirSync(dir, { recursive: true })
+      fs.rmSync(dir, { recursive: true })
     }
     fs.mkdirSync(dir)
   } catch (e) {


### PR DESCRIPTION
Node complains on each test run:
```
[DEP0147] DeprecationWarning: In future versions of Node.js, fs.rmdir(path, { recursive: true }) will be removed. Use fs.rm(path, { recursive: true }) instead
```

rmDirSync with recursive flag is deprecated. Replaced with rmSync() instead.