### PR TITLE
Mongo-memory-server 8.3 does not run on Ubuntu 24 #81

### DIFF
--- a/examples/test.it.js
+++ b/examples/test.it.js
@@ -1,25 +1,35 @@
 const expect = require('chai').expect
 const mongoUnit = require('../index')
-const testMongoUrl = process.env.MONGO_URL
+const mongoose = require('mongoose')
 const testData = require('./fixtures/testData.json')
 
 let service
-mongoUnit.start({ dbName: 'example' }).then(() => {
-  process.env.MONGO_URL = mongoUnit.getUrl()
-  run() // this line start mocha tests
-})
+mongoUnit.start({ dbName: 'example' })
+    .then(() => {
+        const baseUrl = mongoUnit.getUrl()
+        process.env.MONGO_URL = baseUrl + 'example'
+        mongoose.set('strictQuery', false)
+        service = require('./app/service')
+        return new Promise(resolve => setTimeout(resolve, 500))
+    })
+    .then(() => {
+        run()
+    })
+    .catch(err => {
+        console.error('Test initialization error:', err)
+        process.exit(1)
+    })
 
-after(async () => {
+after(async function() {
+  this.timeout(10000)
   const client = service.getClient()
-  await client.disconnect()
+  if (client) {
+    await client.disconnect()
+  }
   await mongoUnit.stop()
 })
 
 describe('service', () => {
-  before(() => {
-    // create it after DB is started
-    service = require('./app/service')
-  })
   beforeEach(() => mongoUnit.initDb(testData))
   afterEach(() => mongoUnit.dropDb())
 

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ const defaultMongoOpts = {
   dbName: 'test',
   dbpath: defaultTempDir,
   port: 27017,
-  useReplicaSet: false
+  useReplicaSet: false,
+  storageEngine: 'wiredTiger'
 }
 
 let mongod = null
@@ -56,13 +57,13 @@ async function runMongo(opts, port) {
       port: port,
       dbPath: opts.dbpath,
       dbName: opts.dbName,
-      storageEngine: storageEngine || 'ephemeralForTest',
+      storageEngine: storageEngine || 'wiredTiger',
     }
     mongod = await MongoMemoryServer.create(options)
     await mongod.ensureInstance()
   }
   dbUrl = mongod.getUri()
-  client = await MongoClient.connect(dbUrl, { useUnifiedTopology: true })
+  client = await MongoClient.connect(dbUrl)
   return dbUrl
 }
 
@@ -88,8 +89,8 @@ function delay(time) {
 }
 
 async function stop() {
-  await  client.close(true)
-  await mongod.stop(true)
+  await client.close()
+  await mongod.stop()
   dbUrl = null
   await delay(100) //this is small delay to make sure kill signal is sent
 }

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "homepage": "https://github.com/mikhail-angelov/mongo-unit#readme",
   "dependencies": {
     "debug": "^4.3.3",
-    "mongodb": "^4.3.1",
-    "mongodb-memory-server": "^8.3.0",
+    "mongodb": "^6.0.0",
+    "mongodb-memory-server": "^10.0.0",
     "portfinder": "^1.0.28",
     "ps-node": "^0.1.6"
   },

--- a/test.js
+++ b/test.js
@@ -28,16 +28,14 @@ describe('mongo-unit', function () {
 
   it('should connect to db and CRUD docs', () =>
     co(function* () {
-      const client = yield MongoClient.connect(mongoUnit.getUrl(), {
-        useUnifiedTopology: true,
-      })
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
       const collection = db.collection('test')
       yield collection.insertOne({ doc: 1 })
       let results = yield collection.find().toArray()
       expect(results.length).to.equal(1)
       expect(results[0].doc).to.equal(1)
-      yield collection.remove({ doc: 1 })
+      yield collection.deleteMany({ doc: 1 })
       results = yield collection.find().toArray()
       expect(results.length).to.equal(0)
       yield client.close()
@@ -46,9 +44,7 @@ describe('mongo-unit', function () {
   it('should load collection data', () =>
     co(function* () {
       yield mongoUnit.load(testData)
-      const client = yield MongoClient.connect(mongoUnit.getUrl(), {
-        useUnifiedTopology: true,
-      })
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
       const collection1 = db.collection('col1')
       const collection2 = db.collection('col2')
@@ -65,9 +61,7 @@ describe('mongo-unit', function () {
     co(function* () {
       yield mongoUnit.load(testData)
       yield mongoUnit.clean(testData)
-      const client = yield MongoClient.connect(mongoUnit.getUrl(), {
-        useUnifiedTopology: true,
-      })
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
       const collection1 = db.collection('col1')
       const collection2 = db.collection('col2')
@@ -82,9 +76,7 @@ describe('mongo-unit', function () {
     co(function* () {
       const url = mongoUnit.getUrl()
       yield mongoUnit.initDb(testData)
-      const client = yield MongoClient.connect(mongoUnit.getUrl(), {
-        useUnifiedTopology: true,
-      })
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
       const collection1 = db.collection('col1')
       const collection2 = db.collection('col2')
@@ -99,9 +91,7 @@ describe('mongo-unit', function () {
     co(function* () {
       yield mongoUnit.initDb(testData)
       yield mongoUnit.dropDb()
-      const client = yield MongoClient.connect(mongoUnit.getUrl(), {
-        useUnifiedTopology: true,
-      })
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
       const collections = yield db.listCollections().toArray()
       expect(collections.length).to.equal(0)
@@ -154,9 +144,7 @@ describe('mongo-unit', function () {
     await mongoUnit.start({ dbName: DB_NAME, useReplicaSet: true })
 
     await mongoUnit.load(testData)
-    const client = await MongoClient.connect(mongoUnit.getUrl(), {
-      useUnifiedTopology: true,
-    })
+    const client = await MongoClient.connect(mongoUnit.getUrl())
     const db = client.db(DB_NAME)
     const collection1 = db.collection('col1')
     let results = await collection1.find().toArray()


### PR DESCRIPTION
### Description
This PR resolves **Issue #81**, fixing the inability to run `mongo-unit` on modern Linux distributions (like Ubuntu 24.04 inside GitHub Actions) due to the legacy `mongodb-memory-server` v8 dependency requiring an obsolete `libcrypto.so.1.1` binary.

Additionally, this update implicitly resolves **Issue #79** by migrating away from the deprecated `ephemeralForTest` storage engine.

### Key Changes
1. **Dependency Upgrades:**
   * Upgraded `mongodb-memory-server` to **v10** (fixes the OS compatibility layer).
   * Upgraded native `mongodb` driver to **v6** to align with the new MMS specifications.

2. **Core Logic & Architectural Adjustments (`index.js`):**
   * Changed the default `storageEngine` from `ephemeralForTest` to `wiredTiger` for both standalone and Replica Set environments, as `ephemeralForTest` is completely unsupported starting from MongoDB 7.0+. Users can still manually override this via `opts.storageEngine`.
   * Cleared deprecated connection parameters like `{ useUnifiedTopology: true }`.

3. **Test Suite Modernization:**
   * Replaced the obsolete `.remove()` calls with `.deleteMany()` in internal tests to follow native driver v6 API.
   * **Examples (`examples/test.it.js`):** Fixed race conditions introduced by modern Mongoose asynchronous connection routines by replacing the legacy interval loop with a streamlined connection logic and adjusted the Mocha `after` hook timeout via `this.timeout(10000)` to safely accommodate the heavier `wiredTiger` process teardown.

Closes #81
Closes #79