### PR TITLE
No option to initialize database with indexes #45

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Inserts given data into DB collections, returns Promise. Data can be provided in
     }
     ```
 
-2.  **Object with `indexes` and `documents` (to define indexes):**
+2.  **Object with `indexes` and `documents` (to define required indexes explicitly in fixture data):**
     ```json
     {
       "users": {
@@ -189,7 +189,12 @@ Inserts given data into DB collections, returns Promise. Data can be provided in
       }
     }
     ```
-This allows you to define indexes (e.g., unique indexes) which will be created before documents are inserted.
+
+This object form lets you declare any indexes that the fixture data needs (for example, unique indexes used to test duplicate-key behavior). All indexes for all collections are created first, and only then are the documents inserted, so the indexes are enforced against the fixture data itself.
+
+> **Note:** mongo-unit does **not** read or infer indexes from Mongoose schemas (or any other schema definition). You have to declare the indexes you want in the fixture data explicitly.
+
+If `indexes` or `documents` is provided but is not an array, `load()` rejects with a clear error so that typos such as `indicies` or `document` do not silently leave the collection empty. `createIndexes()` is only called when `indexes` is a non-empty array.
 
 ### `clean(data)`
 Clear collections based on given data (data format is the same), returns Promise.
@@ -198,7 +203,7 @@ Clear collections based on given data (data format is the same), returns Promise
 Drops test DB, returns Promise.
 
 ### `initDb(data)`
-Helper function to load database data into Mongo. Supports the same data formats as [`load(data)`] for specifying documents and indexes.
+Helper function to load database data into Mongo. Accepts the same data formats as `load(data)`, including the `{ indexes, documents }` object form for declaring required indexes in fixture data.
 
 ### `dropDb()`
 helper function, clear all db data from mongo

--- a/README.md
+++ b/README.md
@@ -159,20 +159,37 @@ It stops mongod process
 Syncronius API returns URL to connect to test db, if test DB is not started it thows an Exception
 
 ### `load(data)`
-Inserts given data (like below) DB collections, returns Promise.
+Inserts given data into DB collections, returns Promise. Data can be provided in two formats:
 
-```json
-{
-  "collectionName1":[
-    {"field1":"value1"},
-    {"field2":"value2"}
-  ],
-  "collectionName2":[
-    {"field3":"value3"},
-    {"field4":"value4"}
-  ]
-}
-```
+1.  **Simple array of documents (backward compatible):**
+    ```json
+    {
+      "collectionName1":[
+        {"field1":"value1"},
+        {"field2":"value2"}
+      ],
+      "collectionName2":[
+        {"field3":"value3"},
+        {"field4":"value4"}
+      ]
+    }
+    ```
+
+2.  **Object with `indexes` and `documents` (to define indexes):**
+    ```json
+    {
+      "users": {
+        "indexes": [
+          { "key": { "email": 1 }, "name": "email_unique_idx", "unique": true },
+          { "key": { "name": 1 }, "name": "name_idx" }
+        ],
+        "documents": [
+          { "name": "Test User", "email": "test@example.com" }
+        ]
+      }
+    }
+    ```
+This allows you to define indexes (e.g., unique indexes) which will be created before documents are inserted.
 
 ### `clean(data)`
 Clear collections based on given data (data format is the same), returns Promise.
@@ -181,7 +198,7 @@ Clear collections based on given data (data format is the same), returns Promise
 Drops test DB, returns Promise.
 
 ### `initDb(data)`
-helper function, load db data into mongo
+Helper function to load database data into Mongo. Supports the same data formats as [`load(data)`] for specifying documents and indexes.
 
 ### `dropDb()`
 helper function, clear all db data from mongo

--- a/index.d.ts
+++ b/index.d.ts
@@ -8,13 +8,33 @@ declare module 'mongo-unit' {
 
     export function getUrl(): string;
 
-    export function load(data: object): Promise<void>;
+    /**
+     * Loads fixture data into the in-memory MongoDB.
+     *
+     * The value of each collection entry can be either:
+     *  - a plain array of documents (legacy format, no indexes supported), or
+     *  - a {@link CollectionData} object that explicitly declares `indexes` and `documents`.
+     *
+     * When the new format is used, all indexes are created for every collection
+     * before any document is inserted, so unique-index constraints are enforced
+     * against the fixture data itself.
+     *
+     * Throws if `indexes` or `documents` is present but is not an array.
+     */
+    export function load(data: Record<string, CollectionData | any[]>): Promise<void>;
 
-    export function clear(data: object): Promise<void>;
+    export function clean(data: Record<string, any>): Promise<void>;
 
     export function drop(): Promise<void>;
 
-    export function initDb(data: object): Promise<void>;
+    /**
+     * Initializes the test database with fixture data.
+     *
+     * Accepts the same data shape as {@link load}: each value is either an
+     * array of documents or a {@link CollectionData} object describing
+     * `indexes` and `documents`.
+     */
+    export function initDb(data: Record<string, CollectionData | any[]>): Promise<void>;
 
     export function dropDb(): Promise<void>;
 
@@ -25,5 +45,25 @@ declare module 'mongo-unit' {
         verbose: boolean;
         version: string;
         useReplicaSet?: boolean;
+    }
+
+    /**
+     * Explicit description of a collection's indexes and seed documents.
+     *
+     * Use this object form (instead of a bare array) when you need to declare
+     * indexes for the collection, e.g. to test unique constraints or other
+     * index-based behavior.
+     */
+    export interface CollectionData {
+        /**
+         * Index specifications passed directly to the MongoDB driver's
+         * `createIndexes()`. Must be an array if present.
+         */
+        indexes?: any[];
+        /**
+         * Seed documents inserted after the indexes are created.
+         * Must be an array if present.
+         */
+        documents?: any[];
     }
 }

--- a/index.js
+++ b/index.js
@@ -2,7 +2,10 @@
 const Debug = require('debug')
 const portfinder = require('portfinder')
 const MongoClient = require('mongodb').MongoClient
-const { MongoMemoryServer, MongoMemoryReplSet } = require('mongodb-memory-server')
+const {
+  MongoMemoryServer,
+  MongoMemoryReplSet,
+} = require('mongodb-memory-server')
 const fs = require('fs')
 const ps = require('ps-node')
 const debug = Debug('mongo-unit')
@@ -14,7 +17,7 @@ const defaultMongoOpts = {
   dbpath: defaultTempDir,
   port: 27017,
   useReplicaSet: false,
-  storageEngine: 'wiredTiger'
+  storageEngine: 'wiredTiger',
 }
 
 let mongod = null
@@ -24,16 +27,16 @@ let dbName
 
 async function runMongo(opts, port) {
   const options = {
-    autoStart: false
+    autoStart: false,
   }
 
   if (opts.version) {
     options.binary = { version: opts.version }
   }
 
-  let storageEngine;
+  let storageEngine
   if (opts.storageEngine) {
-    storageEngine = opts.storageEngine;
+    storageEngine = opts.storageEngine
   }
 
   if (opts.useReplicaSet) {
@@ -42,7 +45,7 @@ async function runMongo(opts, port) {
         port: port,
         dbPath: opts.dbpath,
         storageEngine: storageEngine || 'wiredTiger',
-      }
+      },
     ]
 
     options.replSet = {
@@ -73,7 +76,7 @@ function start(opts) {
     Debug.enable('mongo-unit')
     Debug.enable('*')
   }
-  dbName = mongo_opts.dbName;
+  dbName = mongo_opts.dbName
   if (dbUrl) {
     return Promise.resolve(dbUrl)
   } else {
@@ -101,7 +104,6 @@ function getUrl() {
   } else {
     throw new Error('Please start mongo-unit first, then use this API')
   }
-
 }
 
 const ALLOWED_COLLECTION_KEYS = ['indexes', 'documents']
@@ -132,7 +134,9 @@ function validateCollectionData(colName, colData) {
     return new Error(
       `mongo-unit: collection "${colName}" has unknown config field(s): ${unknownKeys
         .map(k => `"${k}"`)
-        .join(', ')}. Allowed fields are: ${ALLOWED_COLLECTION_KEYS.map(k => `"${k}"`).join(', ')}.`
+        .join(', ')}. Allowed fields are: ${ALLOWED_COLLECTION_KEYS.map(
+        k => `"${k}"`
+      ).join(', ')}.`
     )
   }
   return

--- a/index.js
+++ b/index.js
@@ -106,6 +106,21 @@ function getUrl() {
 
 const ALLOWED_COLLECTION_KEYS = ['indexes', 'documents']
 
+function validateCollectionValueType(colName, colData) {
+  if (colData === null || colData === undefined) {
+    return
+  }
+  if (Array.isArray(colData)) {
+    return
+  }
+  if (typeof colData === 'object') {
+    return
+  }
+  return new Error(
+    `mongo-unit: collection "${colName}" has invalid fixture value type "${typeof colData}", expected an array or an object.`
+  )
+}
+
 function validateCollectionData(colName, colData) {
   if (!colData || typeof colData !== 'object' || Array.isArray(colData)) {
     return
@@ -125,6 +140,10 @@ function validateCollectionData(colName, colData) {
 
 function createCollectionIndexes(db, colName, colData) {
   const collection = db.collection(colName)
+  const valueTypeError = validateCollectionValueType(colName, colData)
+  if (valueTypeError) {
+    return Promise.reject(valueTypeError)
+  }
   if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
     const validationError = validateCollectionData(colName, colData)
     if (validationError) {
@@ -148,6 +167,10 @@ function createCollectionIndexes(db, colName, colData) {
 
 function insertCollectionDocuments(db, colName, colData) {
   const collection = db.collection(colName)
+  const valueTypeError = validateCollectionValueType(colName, colData)
+  if (valueTypeError) {
+    return Promise.reject(valueTypeError)
+  }
   if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
     if (colData.documents !== undefined) {
       if (!Array.isArray(colData.documents)) {
@@ -170,8 +193,13 @@ function insertCollectionDocuments(db, colName, colData) {
 function load(data) {
   const db = client.db(dbName)
   const colNames = Object.keys(data)
-  return Promise.all(colNames.map(col => createCollectionIndexes(db, col, data[col])))
-    .then(() => Promise.all(colNames.map(col => insertCollectionDocuments(db, col, data[col]))))
+  return Promise.all(
+    colNames.map(col => createCollectionIndexes(db, col, data[col]))
+  ).then(() =>
+    Promise.all(
+      colNames.map(col => insertCollectionDocuments(db, col, data[col]))
+    )
+  )
 }
 
 function clean(data) {
@@ -249,8 +277,13 @@ function makeSureOtherMongoProcessesKilled(dataFolder) {
 function initDb(data) {
   const db = client.db(dbName)
   const colNames = Object.keys(data)
-  return Promise.all(colNames.map(col => createCollectionIndexes(db, col, data[col])))
-    .then(() => Promise.all(colNames.map(col => insertCollectionDocuments(db, col, data[col]))))
+  return Promise.all(
+    colNames.map(col => createCollectionIndexes(db, col, data[col]))
+  ).then(() =>
+    Promise.all(
+      colNames.map(col => insertCollectionDocuments(db, col, data[col]))
+    )
+  )
 }
 
 function dropDb() {

--- a/index.js
+++ b/index.js
@@ -103,13 +103,33 @@ function getUrl() {
   }
 }
 
+function createCollectionIndexes(db, colName, colData) {
+  const collection = db.collection(colName)
+  if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
+    if (colData.indexes && Array.isArray(colData.indexes)) {
+      return collection.createIndexes(colData.indexes)
+    }
+  }
+  return Promise.resolve()
+}
+
+function insertCollectionDocuments(db, colName, colData) {
+  const collection = db.collection(colName)
+  if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
+    if (colData.documents && Array.isArray(colData.documents) && colData.documents.length > 0) {
+      return collection.insertMany(colData.documents)
+    }
+  } else if (Array.isArray(colData) && colData.length > 0) {
+    return collection.insertMany(colData)
+  }
+  return Promise.resolve()
+}
+
 function load(data) {
   const db = client.db(dbName)
-  const queries = Object.keys(data).map(col => {
-    const collection = db.collection(col)
-    return collection.insertMany(data[col])
-  })
-  return Promise.all(queries)
+  const colNames = Object.keys(data)
+  return Promise.all(colNames.map(col => createCollectionIndexes(db, col, data[col])))
+    .then(() => Promise.all(colNames.map(col => insertCollectionDocuments(db, col, data[col]))))
 }
 
 function clean(data) {
@@ -186,11 +206,9 @@ function makeSureOtherMongoProcessesKilled(dataFolder) {
 
 function initDb(data) {
   const db = client.db(dbName)
-  const requests = Object.keys(data).map(col => {
-    const collection = db.collection(col)
-    return collection.insertMany(data[col])
-  })
-  return Promise.all(requests)
+  const colNames = Object.keys(data)
+  return Promise.all(colNames.map(col => createCollectionIndexes(db, col, data[col])))
+    .then(() => Promise.all(colNames.map(col => insertCollectionDocuments(db, col, data[col]))))
 }
 
 function dropDb() {

--- a/index.js
+++ b/index.js
@@ -101,13 +101,23 @@ function getUrl() {
   } else {
     throw new Error('Please start mongo-unit first, then use this API')
   }
+
 }
 
 function createCollectionIndexes(db, colName, colData) {
   const collection = db.collection(colName)
   if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
-    if (colData.indexes && Array.isArray(colData.indexes)) {
-      return collection.createIndexes(colData.indexes)
+    if (colData.indexes !== undefined) {
+      if (!Array.isArray(colData.indexes)) {
+        return Promise.reject(
+          new Error(
+            `mongo-unit: collection "${colName}" has invalid "indexes" field, expected an array.`
+          )
+        )
+      }
+      if (colData.indexes.length > 0) {
+        return collection.createIndexes(colData.indexes)
+      }
     }
   }
   return Promise.resolve()
@@ -116,8 +126,17 @@ function createCollectionIndexes(db, colName, colData) {
 function insertCollectionDocuments(db, colName, colData) {
   const collection = db.collection(colName)
   if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
-    if (colData.documents && Array.isArray(colData.documents) && colData.documents.length > 0) {
-      return collection.insertMany(colData.documents)
+    if (colData.documents !== undefined) {
+      if (!Array.isArray(colData.documents)) {
+        return Promise.reject(
+          new Error(
+            `mongo-unit: collection "${colName}" has invalid "documents" field, expected an array.`
+          )
+        )
+      }
+      if (colData.documents.length > 0) {
+        return collection.insertMany(colData.documents)
+      }
     }
   } else if (Array.isArray(colData) && colData.length > 0) {
     return collection.insertMany(colData)

--- a/index.js
+++ b/index.js
@@ -104,9 +104,32 @@ function getUrl() {
 
 }
 
+const ALLOWED_COLLECTION_KEYS = ['indexes', 'documents']
+
+function validateCollectionData(colName, colData) {
+  if (!colData || typeof colData !== 'object' || Array.isArray(colData)) {
+    return
+  }
+  const unknownKeys = Object.keys(colData).filter(
+    key => !ALLOWED_COLLECTION_KEYS.includes(key)
+  )
+  if (unknownKeys.length > 0) {
+    return new Error(
+      `mongo-unit: collection "${colName}" has unknown config field(s): ${unknownKeys
+        .map(k => `"${k}"`)
+        .join(', ')}. Allowed fields are: ${ALLOWED_COLLECTION_KEYS.map(k => `"${k}"`).join(', ')}.`
+    )
+  }
+  return
+}
+
 function createCollectionIndexes(db, colName, colData) {
   const collection = db.collection(colName)
   if (colData && typeof colData === 'object' && !Array.isArray(colData)) {
+    const validationError = validateCollectionData(colName, colData)
+    if (validationError) {
+      return Promise.reject(validationError)
+    }
     if (colData.indexes !== undefined) {
       if (!Array.isArray(colData.indexes)) {
         return Promise.reject(

--- a/test.js
+++ b/test.js
@@ -222,6 +222,24 @@ describe('mongo-unit', function () {
       )
   })
 
+  it('should throw on invalid collection fixture value type for initDb', () => {
+    const data = {
+      users: 'not-an-array-or-object',
+    }
+    return mongoUnit.initDb(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.initDb() to fail for invalid collection fixture value type'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/invalid fixture value type/i)
+        expect(err.message).to.match(/users/)
+      }
+    )
+  })
+
   it('should throw on unknown collection config fields', () => {
     const data = {
       users: {

--- a/test.js
+++ b/test.js
@@ -139,22 +139,108 @@ describe('mongo-unit', function () {
       yield client.close()
     }))
 
-  it('should enforce unique index', () =>
-    co(function* () {
-      yield mongoUnit.load(testDataWithIndexes)
-      const client = yield MongoClient.connect(mongoUnit.getUrl())
-      const db = client.db(DB_NAME)
-      const collection = db.collection('users')
-      let error = null
-      try {
-        yield collection.insertOne({ name: 'Duplicate', email: 'test@example.com' })
-      } catch (err) {
-        error = err
+  it('should enforce unique index during load() itself', () => {
+    const dataWithDuplicateUniqueValues = {
+      users: {
+        indexes: [{ key: { email: 1 }, name: 'email_unique_idx', unique: true }],
+        documents: [
+          { name: 'Alice', email: 'duplicate@example.com' },
+          { name: 'Bob', email: 'duplicate@example.com' }
+        ]
       }
-      expect(error).to.exist
-      expect(error.code).to.equal(11000)
-      yield client.close()
-    }))
+    }
+    return mongoUnit
+      .load(dataWithDuplicateUniqueValues)
+      .then(
+        () => {
+          throw new Error('expected mongoUnit.load() to fail for duplicate unique values')
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.code).to.equal(11000)
+        }
+      )
+  })
+
+  it('should throw on invalid "indexes" field type', () => {
+    const data = {
+      users: {
+        indexes: 'not-an-array',
+        documents: []
+      }
+    }
+    return mongoUnit
+      .load(data)
+      .then(
+        () => {
+          throw new Error('expected mongoUnit.load() to fail for invalid indexes type')
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.message).to.match(/indexes/)
+        }
+      )
+  })
+
+  it('should throw on invalid "documents" field type', () => {
+    const data = {
+      users: {
+        indexes: [],
+        documents: 'not-an-array'
+      }
+    }
+    return mongoUnit
+      .load(data)
+      .then(
+        () => {
+          throw new Error('expected mongoUnit.load() to fail for invalid documents type')
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.message).to.match(/documents/)
+        }
+      )
+  })
+
+  it('should throw on invalid "indexes" field type for initDb', () => {
+    const data = {
+      users: {
+        indexes: 'not-an-array',
+        documents: []
+      }
+    }
+    return mongoUnit
+      .initDb(data)
+      .then(
+        () => {
+          throw new Error('expected mongoUnit.initDb() to fail for invalid indexes type')
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.message).to.match(/indexes/)
+        }
+      )
+  })
+
+  it('should throw on invalid "documents" field type for initDb', () => {
+    const data = {
+      users: {
+        indexes: [],
+        documents: 'not-an-array'
+      }
+    }
+    return mongoUnit
+      .initDb(data)
+      .then(
+        () => {
+          throw new Error('expected mongoUnit.initDb() to fail for invalid documents type')
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.message).to.match(/documents/)
+        }
+      )
+  })
 
   //   it('should list mongo',(done)=>{
 

--- a/test.js
+++ b/test.js
@@ -6,7 +6,7 @@ const co = require('co')
 
 const DB_NAME = 'test'
 
-describe('mongo-unit', function () {
+describe('mongo-unit', function() {
   this.timeout(10000000)
   const mongoUnit = require('./index')
   const testData = {
@@ -17,12 +17,10 @@ describe('mongo-unit', function () {
     users: {
       indexes: [
         { key: { email: 1 }, name: 'email_unique_idx', unique: true },
-        { key: { name: 1 }, name: 'name_idx' }
+        { key: { name: 1 }, name: 'name_idx' },
       ],
-      documents: [
-        { name: 'Test User', email: 'test@example.com' }
-      ]
-    }
+      documents: [{ name: 'Test User', email: 'test@example.com' }],
+    },
   }
 
   before(() => mongoUnit.start({ dbName: DB_NAME }))
@@ -38,7 +36,7 @@ describe('mongo-unit', function () {
   })
 
   it('should connect to db and CRUD docs', () =>
-    co(function* () {
+    co(function*() {
       const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
       const collection = db.collection('test')
@@ -53,7 +51,7 @@ describe('mongo-unit', function () {
     }))
 
   it('should load collection data', () =>
-    co(function* () {
+    co(function*() {
       yield mongoUnit.load(testData)
       const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
@@ -69,7 +67,7 @@ describe('mongo-unit', function () {
     }))
 
   it('should clean collection data', () =>
-    co(function* () {
+    co(function*() {
       yield mongoUnit.load(testData)
       yield mongoUnit.clean(testData)
       const client = yield MongoClient.connect(mongoUnit.getUrl())
@@ -84,7 +82,7 @@ describe('mongo-unit', function () {
     }))
 
   it('should init DB data for given URL', () =>
-    co(function* () {
+    co(function*() {
       const url = mongoUnit.getUrl()
       yield mongoUnit.initDb(testData)
       const client = yield MongoClient.connect(mongoUnit.getUrl())
@@ -99,7 +97,7 @@ describe('mongo-unit', function () {
     }))
 
   it('should dropDb DB data for given URL', () =>
-    co(function* () {
+    co(function*() {
       yield mongoUnit.initDb(testData)
       yield mongoUnit.dropDb()
       const client = yield MongoClient.connect(mongoUnit.getUrl())
@@ -110,7 +108,7 @@ describe('mongo-unit', function () {
     }))
 
   it('should create indexes with load function', () =>
-    co(function* () {
+    co(function*() {
       yield mongoUnit.load(testDataWithIndexes)
       const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
@@ -127,7 +125,7 @@ describe('mongo-unit', function () {
     }))
 
   it('should create indexes with initDb function', () =>
-    co(function* () {
+    co(function*() {
       yield mongoUnit.initDb(testDataWithIndexes)
       const client = yield MongoClient.connect(mongoUnit.getUrl())
       const db = client.db(DB_NAME)
@@ -142,84 +140,104 @@ describe('mongo-unit', function () {
   it('should enforce unique index during load() itself', () => {
     const dataWithDuplicateUniqueValues = {
       users: {
-        indexes: [{ key: { email: 1 }, name: 'email_unique_idx', unique: true }],
+        indexes: [
+          { key: { email: 1 }, name: 'email_unique_idx', unique: true },
+        ],
         documents: [
           { name: 'Alice', email: 'duplicate@example.com' },
-          { name: 'Bob', email: 'duplicate@example.com' }
-        ]
-      }
+          { name: 'Bob', email: 'duplicate@example.com' },
+        ],
+      },
     }
-    return mongoUnit
-      .load(dataWithDuplicateUniqueValues)
-      .then(
-        () => {
-          throw new Error('expected mongoUnit.load() to fail for duplicate unique values')
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.code).to.equal(11000)
-        }
-      )
+    return mongoUnit.load(dataWithDuplicateUniqueValues).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.load() to fail for duplicate unique values'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.code).to.equal(11000)
+      }
+    )
   })
 
   it('should throw on invalid "indexes" field type', () => {
     const data = {
       users: {
         indexes: 'not-an-array',
-        documents: []
-      }
+        documents: [],
+      },
     }
-    return mongoUnit
-      .load(data)
-      .then(
-        () => {
-          throw new Error('expected mongoUnit.load() to fail for invalid indexes type')
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.message).to.match(/indexes/)
-        }
-      )
+    return mongoUnit.load(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.load() to fail for invalid indexes type'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/indexes/)
+      }
+    )
   })
 
   it('should throw on invalid "documents" field type', () => {
     const data = {
       users: {
         indexes: [],
-        documents: 'not-an-array'
-      }
+        documents: 'not-an-array',
+      },
     }
-    return mongoUnit
-      .load(data)
-      .then(
-        () => {
-          throw new Error('expected mongoUnit.load() to fail for invalid documents type')
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.message).to.match(/documents/)
-        }
-      )
+    return mongoUnit.load(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.load() to fail for invalid documents type'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/documents/)
+      }
+    )
+  })
+
+  it('should throw on invalid collection fixture value type', () => {
+    const data = {
+      users: 'not-an-array-or-object',
+    }
+    return mongoUnit.load(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.load() to fail for invalid collection fixture value type'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/invalid fixture value type/i)
+        expect(err.message).to.match(/users/)
+      }
+    )
   })
 
   it('should throw on invalid "indexes" field type for initDb', () => {
     const data = {
       users: {
         indexes: 'not-an-array',
-        documents: []
-      }
+        documents: [],
+      },
     }
-    return mongoUnit
-      .initDb(data)
-      .then(
-        () => {
-          throw new Error('expected mongoUnit.initDb() to fail for invalid indexes type')
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.message).to.match(/indexes/)
-        }
-      )
+    return mongoUnit.initDb(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.initDb() to fail for invalid indexes type'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/indexes/)
+      }
+    )
   })
 
   it('should throw on invalid collection fixture value type for initDb', () => {
@@ -244,64 +262,62 @@ describe('mongo-unit', function () {
     const data = {
       users: {
         indicies: [],
-        document: []
-      }
+        document: [],
+      },
     }
-    return mongoUnit
-      .load(data)
-      .then(
-        () => {
-          throw new Error('expected mongoUnit.load() to fail for unknown collection config fields')
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.message).to.match(/unknown/i)
-          expect(err.message).to.match(/indicies/)
-          expect(err.message).to.match(/document/)
-        }
-      )
+    return mongoUnit.load(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.load() to fail for unknown collection config fields'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/unknown/i)
+        expect(err.message).to.match(/indicies/)
+        expect(err.message).to.match(/document/)
+      }
+    )
   })
 
   it('should throw on unknown collection config fields for initDb', () => {
     const data = {
       users: {
-        indicies: []
-      }
+        indicies: [],
+      },
     }
-    return mongoUnit
-      .initDb(data)
-      .then(
-        () => {
-          throw new Error(
-            'expected mongoUnit.initDb() to fail for unknown collection config fields'
-          )
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.message).to.match(/unknown/i)
-          expect(err.message).to.match(/indicies/)
-        }
-      )
+    return mongoUnit.initDb(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.initDb() to fail for unknown collection config fields'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/unknown/i)
+        expect(err.message).to.match(/indicies/)
+      }
+    )
   })
 
   it('should throw on invalid "documents" field type for initDb', () => {
     const data = {
       users: {
         indexes: [],
-        documents: 'not-an-array'
-      }
+        documents: 'not-an-array',
+      },
     }
-    return mongoUnit
-      .initDb(data)
-      .then(
-        () => {
-          throw new Error('expected mongoUnit.initDb() to fail for invalid documents type')
-        },
-        err => {
-          expect(err).to.exist
-          expect(err.message).to.match(/documents/)
-        }
-      )
+    return mongoUnit.initDb(data).then(
+      () => {
+        throw new Error(
+          'expected mongoUnit.initDb() to fail for invalid documents type'
+        )
+      },
+      err => {
+        expect(err).to.exist
+        expect(err.message).to.match(/documents/)
+      }
+    )
   })
 
   //   it('should list mongo',(done)=>{

--- a/test.js
+++ b/test.js
@@ -13,6 +13,17 @@ describe('mongo-unit', function () {
     col1: [{ doc: 1 }, { doc: 2 }],
     col2: [{ rec: 1 }, { rec: 2 }],
   }
+  const testDataWithIndexes = {
+    users: {
+      indexes: [
+        { key: { email: 1 }, name: 'email_unique_idx', unique: true },
+        { key: { name: 1 }, name: 'name_idx' }
+      ],
+      documents: [
+        { name: 'Test User', email: 'test@example.com' }
+      ]
+    }
+  }
 
   before(() => mongoUnit.start({ dbName: DB_NAME }))
 
@@ -95,6 +106,53 @@ describe('mongo-unit', function () {
       const db = client.db(DB_NAME)
       const collections = yield db.listCollections().toArray()
       expect(collections.length).to.equal(0)
+      yield client.close()
+    }))
+
+  it('should create indexes with load function', () =>
+    co(function* () {
+      yield mongoUnit.load(testDataWithIndexes)
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
+      const db = client.db(DB_NAME)
+      const collection = db.collection('users')
+      const indexes = yield collection.listIndexes().toArray()
+      const indexNames = indexes.map(idx => idx.name)
+      expect(indexNames).to.include('email_unique_idx')
+      expect(indexNames).to.include('name_idx')
+      const users = yield collection.find().toArray()
+      expect(users.length).to.equal(1)
+      expect(users[0].name).to.equal('Test User')
+      expect(users[0].email).to.equal('test@example.com')
+      yield client.close()
+    }))
+
+  it('should create indexes with initDb function', () =>
+    co(function* () {
+      yield mongoUnit.initDb(testDataWithIndexes)
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
+      const db = client.db(DB_NAME)
+      const collection = db.collection('users')
+      const indexes = yield collection.listIndexes().toArray()
+      const indexNames = indexes.map(idx => idx.name)
+      expect(indexNames).to.include('email_unique_idx')
+      expect(indexNames).to.include('name_idx')
+      yield client.close()
+    }))
+
+  it('should enforce unique index', () =>
+    co(function* () {
+      yield mongoUnit.load(testDataWithIndexes)
+      const client = yield MongoClient.connect(mongoUnit.getUrl())
+      const db = client.db(DB_NAME)
+      const collection = db.collection('users')
+      let error = null
+      try {
+        yield collection.insertOne({ name: 'Duplicate', email: 'test@example.com' })
+      } catch (err) {
+        error = err
+      }
+      expect(error).to.exist
+      expect(error.code).to.equal(11000)
       yield client.close()
     }))
 

--- a/test.js
+++ b/test.js
@@ -222,6 +222,50 @@ describe('mongo-unit', function () {
       )
   })
 
+  it('should throw on unknown collection config fields', () => {
+    const data = {
+      users: {
+        indicies: [],
+        document: []
+      }
+    }
+    return mongoUnit
+      .load(data)
+      .then(
+        () => {
+          throw new Error('expected mongoUnit.load() to fail for unknown collection config fields')
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.message).to.match(/unknown/i)
+          expect(err.message).to.match(/indicies/)
+          expect(err.message).to.match(/document/)
+        }
+      )
+  })
+
+  it('should throw on unknown collection config fields for initDb', () => {
+    const data = {
+      users: {
+        indicies: []
+      }
+    }
+    return mongoUnit
+      .initDb(data)
+      .then(
+        () => {
+          throw new Error(
+            'expected mongoUnit.initDb() to fail for unknown collection config fields'
+          )
+        },
+        err => {
+          expect(err).to.exist
+          expect(err.message).to.match(/unknown/i)
+          expect(err.message).to.match(/indicies/)
+        }
+      )
+  })
+
   it('should throw on invalid "documents" field type for initDb', () => {
     const data = {
       users: {


### PR DESCRIPTION
### Description

This pull request adds important functionality that allows you to initialize a MongoDB database with specified indexes when using the [`mongoUnit.load()`] and [`mongoUnit.initDb()`] functions.

Previously, [`mongo-unit`](README.md) did not apply indexes defined in models (e.g., `mongoose`), which prevented full testing of APIs that rely on unique or other types of indexes to ensure data integrity. This change addresses this issue, enabling more realistic and robust integration tests.

### Changes

1. **Extended data format for `load` and `initDb`:** The [`mongoUnit.load()`] and [`mongoUnit.initDb()`](README.md:183) functions now accept a new data format that allows you to explicitly specify the `indexes` and `documents` arrays for each collection.
2. **Creating indexes before inserting documents:** The logic of these functions has been changed to create all specified indexes first, and then insert the documents. This ensures that all index constraints (such as uniqueness) remain in effect during data insertion.
3. **Backward compatibility:** The new functionality is fully backwards compatible. Existing test data that uses the old format (simply an array of documents for a collection) will continue to work without modification. 4. **Updated Documentation:** The [`README.md`](README.md) file has been updated to clearly describe the new data format and examples of its use.

### Example of using the new data format

To define indexes, use the following structure:

```json
{
"users": {
"indexes": [
{ "key": { "email": 1 }, "name": "email_unique_idx", "unique": true },
{ "key": { "name": 1 }, "name": "name_idx" }
],
"documents": [
{ "name": "Test User", "email": "test@example.com" }
]
}
}

Testing
New unit tests (test.js) are included that demonstrate the correct creation of indexes using load and initDb, and also confirm that unique indexes are successfully applied (by checking for an error when attempting to insert duplicates).